### PR TITLE
Pytest and change to coeff_exp

### DIFF
--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -297,6 +297,7 @@ install(DIRECTORY ../tests/pytests/
         PATTERN "standard_suite_runner.py"
         PATTERN "tdscf_reference_data.json"
         PATTERN "oei_reference_data.json"
+        PATTERN "f12_libint1.json"
         PATTERN "utils.py")
 install(DIRECTORY ../tests/pytests/test_fchk_writer
                   ../tests/pytests/test_molden_writer

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1484,6 +1484,7 @@ void export_mints(py::module& m) {
         .def("ao_f12g12", &MintsHelper::ao_f12g12, "AO F12G12 integrals", "corr"_a)
         .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator, "AO F12 double commutator integrals",
              "corr"_a)
+	.def("f12_cgtg", &MintsHelper::f12_cgtg, "F12 Fitted Slater Correlation Factor", "exponent"_a = 1.0)
         .def("ao_3coverlap", normal_eri(&MintsHelper::ao_3coverlap), "3 Center overlap integrals")
         .def("ao_3coverlap", normal_3c(&MintsHelper::ao_3coverlap), "3 Center overlap integrals", "bs1"_a, "bs2"_a,
              "bs3"_a)

--- a/psi4/src/psi4/libmints/eri.cc
+++ b/psi4/src/psi4/libmints/eri.cc
@@ -610,7 +610,7 @@ Libint2YukawaERI::~Libint2YukawaERI(){};
 
 /// F12
 
-Libint2F12::Libint2F12(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+Libint2F12::Libint2F12(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                        double screening_threshold, int deriv, bool use_shell_pairs, bool needs_exchange)
     : Libint2TwoElectronInt(integral, deriv, screening_threshold, use_shell_pairs, needs_exchange) {
     timer_on("Libint2F12::Libint2F12");
@@ -638,10 +638,10 @@ Libint2F12::Libint2F12(std::vector<std::pair<double, double>> coeff_exp, const I
     }
 
     for (int der = 0; der <= deriv; ++der) {
-        engines_.emplace_back(libint2::Operator::cgtg, max_nprim, max_am, der, max_precision, coeff_exp, braket_);
+        engines_.emplace_back(libint2::Operator::cgtg, max_nprim, max_am, der, max_precision, exp_coeff, braket_);
     }
     max_am = bra_same_ ? basis1()->max_am() : ket_same_ ? basis3()->max_am() : 0;
-    schwarz_engine_ = libint2::Engine(libint2::Operator::cgtg, max_nprim, max_am, 0, max_precision, coeff_exp,
+    schwarz_engine_ = libint2::Engine(libint2::Operator::cgtg, max_nprim, max_am, 0, max_precision, exp_coeff,
                                       libint2::BraKet::xx_xx);
     common_init();
     timer_off("Libint2F12::Libint2F12");
@@ -713,7 +713,7 @@ Libint2F12::~Libint2F12(){};
 
 /// F12G12
 
-Libint2F12G12::Libint2F12G12(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+Libint2F12G12::Libint2F12G12(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                              double screening_threshold, int deriv, bool use_shell_pairs, bool needs_exchange)
     : Libint2TwoElectronInt(integral, deriv, screening_threshold, use_shell_pairs, needs_exchange) {
     timer_on("Libint2F12G12::Libint2F12G12");
@@ -741,11 +741,11 @@ Libint2F12G12::Libint2F12G12(std::vector<std::pair<double, double>> coeff_exp, c
     }
 
     for (int der = 0; der <= deriv; ++der) {
-        engines_.emplace_back(libint2::Operator::cgtg_x_coulomb, max_nprim, max_am, der, max_precision, coeff_exp,
+        engines_.emplace_back(libint2::Operator::cgtg_x_coulomb, max_nprim, max_am, der, max_precision, exp_coeff,
                               braket_);
     }
     max_am = bra_same_ ? basis1()->max_am() : ket_same_ ? basis3()->max_am() : 0;
-    schwarz_engine_ = libint2::Engine(libint2::Operator::cgtg_x_coulomb, max_nprim, max_am, 0, max_precision, coeff_exp,
+    schwarz_engine_ = libint2::Engine(libint2::Operator::cgtg_x_coulomb, max_nprim, max_am, 0, max_precision, exp_coeff,
                                       libint2::BraKet::xx_xx);
     common_init();
     timer_off("Libint2F12G12::Libint2F12G12");
@@ -829,7 +829,7 @@ Libint2F12G12::~Libint2F12G12(){};
 
 /// F12DoubleCommutator
 
-Libint2F12DoubleCommutator::Libint2F12DoubleCommutator(std::vector<std::pair<double, double>> coeff_exp,
+Libint2F12DoubleCommutator::Libint2F12DoubleCommutator(std::vector<std::pair<double, double>> exp_coeff,
                                                        const IntegralFactory *integral, double screening_threshold,
                                                        int deriv, bool use_shell_pairs, bool needs_exchange)
     : Libint2TwoElectronInt(integral, deriv, screening_threshold, use_shell_pairs, needs_exchange) {
@@ -858,10 +858,10 @@ Libint2F12DoubleCommutator::Libint2F12DoubleCommutator(std::vector<std::pair<dou
     }
 
     for (int der = 0; der <= deriv; ++der) {
-        engines_.emplace_back(libint2::Operator::delcgtg2, max_nprim, max_am, der, max_precision, coeff_exp, braket_);
+        engines_.emplace_back(libint2::Operator::delcgtg2, max_nprim, max_am, der, max_precision, exp_coeff, braket_);
     }
     max_am = bra_same_ ? basis1()->max_am() : ket_same_ ? basis3()->max_am() : 0;
-    schwarz_engine_ = libint2::Engine(libint2::Operator::delcgtg2, max_nprim, max_am, 0, max_precision, coeff_exp,
+    schwarz_engine_ = libint2::Engine(libint2::Operator::delcgtg2, max_nprim, max_am, 0, max_precision, exp_coeff,
                                       libint2::BraKet::xx_xx);
     common_init();
     timer_off("Libint2F12DoubleCommutator::Libint2F12DoubleCommutator");

--- a/psi4/src/psi4/libmints/eri.h
+++ b/psi4/src/psi4/libmints/eri.h
@@ -349,7 +349,7 @@ class Libint2ErfComplementERI : public Libint2TwoElectronInt {
 
 class Libint2F12 : public Libint2TwoElectronInt {
    public:
-    Libint2F12(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+    Libint2F12(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                double screening_threshold, int deriv = 0, bool use_shell_pairs = false, bool needs_exchange = false);
     ~Libint2F12() override;
     Libint2F12 *clone() const override { return new Libint2F12(*this); }
@@ -370,13 +370,13 @@ inline std::vector<std::pair<double, double>> take_square(std::vector<std::pair<
     auto n = input.size();
     std::vector<std::pair<double, double>> output;
     for (int i = 0; i < n; ++i) {
-        auto c_i = input[i].first;
-        auto e_i = input[i].second;
+        auto e_i = input[i].first;
+        auto c_i = input[i].second;
         for (int j = i; j < n; ++j) {
-            auto c_j = input[j].first;
-            auto e_j = input[j].second;
+            auto e_j = input[j].first;
+            auto c_j = input[j].second;
             double scale = i == j ? 1.0 : 2.0;
-            output.emplace_back(std::make_pair(scale * c_i * c_j, e_i + e_j));
+            output.emplace_back(std::make_pair(e_i + e_j, scale * c_i * c_j));
         }
     }
     return output;
@@ -384,15 +384,15 @@ inline std::vector<std::pair<double, double>> take_square(std::vector<std::pair<
 
 class Libint2F12Squared : public Libint2F12 {
    public:
-    Libint2F12Squared(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+    Libint2F12Squared(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                       double screening_threshold, int deriv = 0, bool use_shell_pairs = false,
                       bool needs_exchange = false)
-        : Libint2F12(take_square(coeff_exp), integral, screening_threshold, deriv, use_shell_pairs, needs_exchange) {}
+        : Libint2F12(take_square(exp_coeff), integral, screening_threshold, deriv, use_shell_pairs, needs_exchange) {}
 };
 
 class Libint2F12G12 : public Libint2TwoElectronInt {
    public:
-    Libint2F12G12(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+    Libint2F12G12(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                   double screening_threshold, int deriv = 0, bool use_shell_pairs = false, bool needs_exchange = false);
     ~Libint2F12G12() override;
     Libint2F12G12 *clone() const override { return new Libint2F12G12(*this); }
@@ -411,7 +411,7 @@ class Libint2F12G12 : public Libint2TwoElectronInt {
 
 class Libint2F12DoubleCommutator : public Libint2TwoElectronInt {
    public:
-    Libint2F12DoubleCommutator(std::vector<std::pair<double, double>> coeff_exp, const IntegralFactory *integral,
+    Libint2F12DoubleCommutator(std::vector<std::pair<double, double>> exp_coeff, const IntegralFactory *integral,
                                double screening_threshold, int deriv = 0, bool use_shell_pairs = false,
                                bool needs_exchange = false);
     ~Libint2F12DoubleCommutator() override;

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -264,23 +264,23 @@ TwoBodyAOInt* IntegralFactory::yukawa_eri(double zeta, int deriv, bool use_shell
     return new Libint2YukawaERI(zeta, this, threshold, deriv, use_shell_pairs, needs_exchange);
 }
 
-TwoBodyAOInt* IntegralFactory::f12(std::vector<std::pair<double, double>> coeff_exp, int deriv, bool use_shell_pairs) {
-    return new Libint2F12(coeff_exp, this, deriv, use_shell_pairs);
+TwoBodyAOInt* IntegralFactory::f12(std::vector<std::pair<double, double>> exp_coeff, int deriv, bool use_shell_pairs) {
+    return new Libint2F12(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12_squared(std::vector<std::pair<double, double>> coeff_exp, int deriv,
+TwoBodyAOInt* IntegralFactory::f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                            bool use_shell_pairs) {
-    return new Libint2F12Squared(coeff_exp, this, deriv, use_shell_pairs);
+    return new Libint2F12Squared(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12g12(std::vector<std::pair<double, double>> coeff_exp, int deriv,
+TwoBodyAOInt* IntegralFactory::f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                       bool use_shell_pairs) {
-    return new Libint2F12G12(coeff_exp, this, deriv, use_shell_pairs);
+    return new Libint2F12G12(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp, int deriv,
+TwoBodyAOInt* IntegralFactory::f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                                      bool use_shell_pairs) {
-    return new Libint2F12DoubleCommutator(coeff_exp, this, deriv, use_shell_pairs);
+    return new Libint2F12DoubleCommutator(exp_coeff, this, deriv, use_shell_pairs);
 }
 
 void IntegralFactory::init_spherical_harmonics(int max_am) {

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -512,19 +512,19 @@ class PSI_API IntegralFactory {
     virtual TwoBodyAOInt* yukawa_eri(double zeta, int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
 
     /// Returns an F12 integral object
-    virtual TwoBodyAOInt* f12(std::vector<std::pair<double, double>> coeff_exp, int deriv = 0,
+    virtual TwoBodyAOInt* f12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                               bool use_shell_pairs = true);
 
     /// Returns an F12 squared integral object
-    virtual TwoBodyAOInt* f12_squared(std::vector<std::pair<double, double>> coeff_exp, int deriv = 0,
+    virtual TwoBodyAOInt* f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                       bool use_shell_pairs = true);
 
     /// Returns an F12G12 integral object
-    virtual TwoBodyAOInt* f12g12(std::vector<std::pair<double, double>> coeff_exp, int deriv = 0,
+    virtual TwoBodyAOInt* f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                  bool use_shell_pairs = true);
 
     /// Returns an F12 double commutator integral object
-    virtual TwoBodyAOInt* f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp, int deriv = 0,
+    virtual TwoBodyAOInt* f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                                 bool use_shell_pairs = true);
 
     /// Returns a general ERI iterator object for any (P Q | R S) in shells

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -888,30 +888,46 @@ SharedMatrix MintsHelper::ao_erfc_eri(double omega) {
     return ao_helper("AO ERFC ERI Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12(std::vector<std::pair<double, double>> coeff_exp) {
-    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12(coeff_exp));
+SharedMatrix MintsHelper::ao_f12(std::vector<std::pair<double, double>> exp_coeff) {
+    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12(exp_coeff));
     return ao_helper("AO F12 Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12(std::vector<std::pair<double, double>> coeff_exp, std::shared_ptr<BasisSet> bs1,
+SharedMatrix MintsHelper::ao_f12(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
                                  std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
                                  std::shared_ptr<BasisSet> bs4) {
     IntegralFactory intf(bs1, bs2, bs3, bs4);
-    std::shared_ptr<TwoBodyAOInt> ints(intf.f12(coeff_exp));
+    std::shared_ptr<TwoBodyAOInt> ints(intf.f12(exp_coeff));
     return ao_helper("AO F12 Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12_squared(std::vector<std::pair<double, double>> coeff_exp) {
-    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12_squared(coeff_exp));
+SharedMatrix MintsHelper::ao_f12_squared(std::vector<std::pair<double, double>> exp_coeff) {
+    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12_squared(exp_coeff));
     return ao_helper("AO F12 Squared Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12_squared(std::vector<std::pair<double, double>> coeff_exp,
+SharedMatrix MintsHelper::ao_f12_squared(std::vector<std::pair<double, double>> exp_coeff,
                                          std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
                                          std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4) {
     IntegralFactory intf(bs1, bs2, bs3, bs4);
-    std::shared_ptr<TwoBodyAOInt> ints(intf.f12_squared(coeff_exp));
+    std::shared_ptr<TwoBodyAOInt> ints(intf.f12_squared(exp_coeff));
     return ao_helper("AO F12 Squared Tensor", ints);
+}
+
+std::vector<std::pair<double, double>> MintsHelper::f12_cgtg(double exponent) {
+    // The fitting coefficients and the exponents
+    std::vector<std::pair<double, double>> exp_coeff = {};
+    std::vector<double> coeffs = {-0.31442480597241274, -0.30369575353387201, -0.16806968430232927,
+                                  -0.098115812152857612, -0.060246640234342785, -0.037263541968504843};
+    std::vector<double> exps = {0.22085085450735284, 1.0040191632019282, 3.6212173098378728,
+                                12.162483236221904, 45.855332448029337, 254.23460688554644};
+
+    for (int i = 0; i < exps.size(); i++){
+        auto exp_scaled = (exponent * exponent) * exps[i];
+        exp_coeff.push_back(std::make_pair(exp_scaled, coeffs[i]));
+    }
+    
+    return exp_coeff;
 }
 
 SharedMatrix MintsHelper::ao_3coverlap_helper(const std::string &label, std::shared_ptr<ThreeCenterOverlapInt> ints) {
@@ -964,13 +980,13 @@ SharedMatrix MintsHelper::ao_3coverlap(std::shared_ptr<BasisSet> bs1, std::share
     return ao_3coverlap_helper("AO 3-Center Overlap Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12g12(std::vector<std::pair<double, double>> coeff_exp) {
-    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12g12(coeff_exp));
+SharedMatrix MintsHelper::ao_f12g12(std::vector<std::pair<double, double>> exp_coeff) {
+    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12g12(exp_coeff));
     return ao_helper("AO F12G12 Tensor", ints);
 }
 
-SharedMatrix MintsHelper::ao_f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp) {
-    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12_double_commutator(coeff_exp));
+SharedMatrix MintsHelper::ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff) {
+    std::shared_ptr<TwoBodyAOInt> ints(integral_->f12_double_commutator(exp_coeff));
     return ao_helper("AO F12 Double Commutator Tensor", ints);
 }
 
@@ -987,30 +1003,30 @@ SharedMatrix MintsHelper::mo_erfc_eri(double omega, SharedMatrix C1, SharedMatri
     return mo_ints;
 }
 
-SharedMatrix MintsHelper::mo_f12(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1, SharedMatrix C2,
+SharedMatrix MintsHelper::mo_f12(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1, SharedMatrix C2,
                                  SharedMatrix C3, SharedMatrix C4) {
-    SharedMatrix mo_ints = mo_eri_helper(ao_f12(coeff_exp), C1, C2, C3, C4);
+    SharedMatrix mo_ints = mo_eri_helper(ao_f12(exp_coeff), C1, C2, C3, C4);
     mo_ints->set_name("MO F12 Tensor");
     return mo_ints;
 }
 
-SharedMatrix MintsHelper::mo_f12_squared(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1,
+SharedMatrix MintsHelper::mo_f12_squared(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1,
                                          SharedMatrix C2, SharedMatrix C3, SharedMatrix C4) {
-    SharedMatrix mo_ints = mo_eri_helper(ao_f12_squared(coeff_exp), C1, C2, C3, C4);
+    SharedMatrix mo_ints = mo_eri_helper(ao_f12_squared(exp_coeff), C1, C2, C3, C4);
     mo_ints->set_name("MO F12 Squared Tensor");
     return mo_ints;
 }
 
-SharedMatrix MintsHelper::mo_f12g12(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1, SharedMatrix C2,
+SharedMatrix MintsHelper::mo_f12g12(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1, SharedMatrix C2,
                                     SharedMatrix C3, SharedMatrix C4) {
-    SharedMatrix mo_ints = mo_eri_helper(ao_f12g12(coeff_exp), C1, C2, C3, C4);
+    SharedMatrix mo_ints = mo_eri_helper(ao_f12g12(exp_coeff), C1, C2, C3, C4);
     mo_ints->set_name("MO F12G12 Tensor");
     return mo_ints;
 }
 
-SharedMatrix MintsHelper::mo_f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1,
+SharedMatrix MintsHelper::mo_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1,
                                                    SharedMatrix C2, SharedMatrix C3, SharedMatrix C4) {
-    SharedMatrix mo_ints = mo_eri_helper(ao_f12_double_commutator(coeff_exp), C1, C2, C3, C4);
+    SharedMatrix mo_ints = mo_eri_helper(ao_f12_double_commutator(exp_coeff), C1, C2, C3, C4);
     mo_ints->set_name("MO F12 Double Commutator Tensor");
     return mo_ints;
 }

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -220,23 +220,25 @@ class PSI_API MintsHelper {
     /// AO ERFC Omega Integrals
     SharedMatrix ao_erfc_eri(double omega);
     /// AO F12 Integrals
-    SharedMatrix ao_f12(std::vector<std::pair<double, double>> coeff_exp);
-    SharedMatrix ao_f12(std::vector<std::pair<double, double>> coeff_exp, std::shared_ptr<BasisSet> bs1,
+    SharedMatrix ao_f12(std::vector<std::pair<double, double>> exp_coeff);
+    SharedMatrix ao_f12(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
                         std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
     /// AO F12 Integrals
-    SharedMatrix ao_f12_scaled(std::vector<std::pair<double, double>> coeff_exp);
-    SharedMatrix ao_f12_scaled(std::vector<std::pair<double, double>> coeff_exp, std::shared_ptr<BasisSet> bs1,
+    SharedMatrix ao_f12_scaled(std::vector<std::pair<double, double>> exp_coeff);
+    SharedMatrix ao_f12_scaled(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
                                std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
                                std::shared_ptr<BasisSet> bs4);
     /// AO F12 squared Integrals
-    SharedMatrix ao_f12_squared(std::vector<std::pair<double, double>> coeff_exp);
-    SharedMatrix ao_f12_squared(std::vector<std::pair<double, double>> coeff_exp, std::shared_ptr<BasisSet> bs1,
+    SharedMatrix ao_f12_squared(std::vector<std::pair<double, double>> exp_coeff);
+    SharedMatrix ao_f12_squared(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
                                 std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3,
                                 std::shared_ptr<BasisSet> bs4);
     /// AO F12G12 Integrals
-    SharedMatrix ao_f12g12(std::vector<std::pair<double, double>> coeff_exp);
+    SharedMatrix ao_f12g12(std::vector<std::pair<double, double>> exp_coeff);
     /// AO F12 double commutator Integrals
-    SharedMatrix ao_f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp);
+    SharedMatrix ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff);
+    /// F12 Fitted Slater Correlation Factor
+    std::vector<std::pair<double, double>> f12_cgtg(double exponent = 1.0);
 
     /// 3Center overlap integrals
     SharedMatrix ao_3coverlap();
@@ -253,16 +255,16 @@ class PSI_API MintsHelper {
     /// MO ERFC Omega Integrals
     SharedMatrix mo_erfc_eri(double omega, SharedMatrix C1, SharedMatrix C2, SharedMatrix C3, SharedMatrix C4);
     /// MO F12 Integrals
-    SharedMatrix mo_f12(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1, SharedMatrix C2,
+    SharedMatrix mo_f12(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1, SharedMatrix C2,
                         SharedMatrix C3, SharedMatrix C4);
     /// MO F12 squared Integrals
-    SharedMatrix mo_f12_squared(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1, SharedMatrix C2,
+    SharedMatrix mo_f12_squared(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1, SharedMatrix C2,
                                 SharedMatrix C3, SharedMatrix C4);
     /// MO F12G12 Integrals
-    SharedMatrix mo_f12g12(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1, SharedMatrix C2,
+    SharedMatrix mo_f12g12(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1, SharedMatrix C2,
                            SharedMatrix C3, SharedMatrix C4);
     /// MO F12 double commutator Integrals
-    SharedMatrix mo_f12_double_commutator(std::vector<std::pair<double, double>> coeff_exp, SharedMatrix C1,
+    SharedMatrix mo_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, SharedMatrix C1,
                                           SharedMatrix C2, SharedMatrix C3, SharedMatrix C4);
 
     /// Symmetric MO ERI Omega Integrals, (ov|ov) type  (Full matrix, N^5, not recommended for large systems)

--- a/tests/pytests/test_f12_ints.py
+++ b/tests/pytests/test_f12_ints.py
@@ -1,0 +1,50 @@
+"""
+This file tests the F12 two-electron integrals from libmints
+"""
+import numpy as np
+import pytest
+import psi4
+from pathlib import Path
+import json
+
+
+pytestmark = [pytest.mark.api, pytest.mark.quick]
+
+
+@pytest.fixture
+def reference_data():
+    # Reference data generated using Psi4 1.5, still using OS86
+    with open(Path(__file__).parent / "f12_libint1.json") as f:
+        reference_data = json.load(f)
+    return reference_data
+    
+def matlist_to_ndarray(mats):
+    """Converts a list of psi4.core.Matrix to np.ndarray"""
+    return psi4.driver.p4util.numpy_helper._to_array(mats) 
+
+def test_f12_integrals(reference_data):
+    assert reference_data['version'] == '1.5'
+    refdata = reference_data['data']
+    moldata = refdata['h2o']
+    mol = psi4.core.Molecule.from_string(moldata.pop('psi4string'))
+
+    basis = psi4.core.BasisSet.build(mol, 'orbital', '6-31G*')
+    mints = psi4.core.MintsHelper(basis)
+    f12 = mints.f12_cgtg(1.0)
+
+    for int_type in ['F', 'F2', 'FG', 'Uf']:
+        ref = moldata[int_type]
+        shape = ref[f'L_shape']
+        integral_ref = np.array(ref["L"]).reshape(shape)
+
+        if int_type == "F":
+            libint2 = mints.ao_f12(f12)
+        if int_type == "F2":
+            libint2 = mints.ao_f12_squared(f12)
+        if int_type == "FG":
+            libint2 = mints.ao_f12g12(f12)
+        if int_type == "Uf":
+            libint2 = mints.ao_f12_double_commutator(f12)
+
+        libint2_np = matlist_to_ndarray(libint2)
+        np.testing.assert_allclose(libint2_np, integral_ref, atol=1.e-14)


### PR DESCRIPTION
## Description
Pytest for Libint2 vs Libint2 integrals and changes to old FittedSlaterCorrelationFactor

## Todos
- [ ] In MintsHelper created f12_cgtg which puts the exponents and coefficients into a vector of pairs

## Checklist
- [ ] Pytest test_f12_ints.py and reference file f12_libint1.json comparing integrals with 6-31G* basis

## Status
- [ ] Ready for review
- [ ] Ready for merge
